### PR TITLE
Update malive shebang to bash to work on Debian

### DIFF
--- a/docker/malive
+++ b/docker/malive
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 function malive_version_list () {
   TAGS=$(curl -s https://registry.hub.docker.com/v2/repositories/malive/malive/tags | sed "s/,/\n/g" | grep \"name\": | cut -d '"' -f 4 | sort -r -V)


### PR DESCRIPTION
On Debian/Ubuntu, /bin/sh is dash, not bash.
Since current malive script uses bash extension, malive script failed with following error.

./malive: 3: Syntax error: "(" unexpected

Change shebang explicitly to bash solves this problem.